### PR TITLE
Update StackExchange.Redis

### DIFF
--- a/Schtick.Redis/Schtick.Redis.csproj
+++ b/Schtick.Redis/Schtick.Redis.csproj
@@ -12,6 +12,6 @@
     <ItemGroup>
       <PackageReference Include="Schtick" Version="2.0.1" />
       <PackageReference Include="Schyntax" Version="2.0.1" />
-      <PackageReference Include="StackExchange.Redis" Version="2.5.61" />
+      <PackageReference Include="StackExchange.Redis" Version="2.6.45" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
I'm working on the SO Redis upgrade and I want to make sure we are using the latest SE.Redis version, it probably won't have an impact but just in case. I'm updating this project cause I see it's used on Calculon. I've build the project locally and run the unit tests.